### PR TITLE
fix: handle unicode entities correctly

### DIFF
--- a/lua/urlpreview/init.lua
+++ b/lua/urlpreview/init.lua
@@ -67,5 +67,6 @@ end
 -- https://davidwalsh.name/twitter-cards
 -- https://excalidraw.com/
 -- https://r4ds.hadley.nz/
+-- https://trafilatura.readthedocs.io/en/latest/index.html
 
 return M

--- a/lua/urlpreview/scrape.lua
+++ b/lua/urlpreview/scrape.lua
@@ -75,7 +75,7 @@ local scrape = function(url, callback)
             -- Replace html numbered character entities, e.g. `&#40;` = `@`
             for k, v in pairs(out) do
                 out[k] = v:gsub("&#(%d+);", function(n)
-                    return string.char(tonumber(n))
+                    return vim.fn.nr2char(tonumber(n, 10))
                 end)
             end
 


### PR DESCRIPTION
This fix allows to convert entities like &#8212; correctly.

Added a link to init.lua that contains it.